### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,7 +48,7 @@ jobs:
         run: echo ::set-output name=tag::$(echo ${GITHUB_SHA::7})
 
       - name: "🐳 Publish image"
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: jmserrano-dev/code-challenge-editor/editor-spa
           registry: docker.pkg.github.com


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore